### PR TITLE
Feat/Close recruitment forms

### DIFF
--- a/app/components/Navbar/navBar.tsx
+++ b/app/components/Navbar/navBar.tsx
@@ -74,7 +74,7 @@ const Navbar = () => {
 
   // Banner settings
   const BANNER_TEXT = <>We&apos;re Recruiting! 👉 <a href="/join" className="underline hover:text-blue-600">Join Us Here</a> 👈 - Apply by August 6th!</>
-  const SHOW_BANNER = true
+  const SHOW_BANNER = false
 
   // Old code for drop down menus
   // const handleItemClick = (item: MobileNavItemsProps) => {

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -4,7 +4,6 @@ import ApplicationCarousel from "../components/ApplicationCarousel/ApplicationCa
 import PageSection from "../components/PageSection";
 import Image from "next/image";
 
-// TODO: Perhaps convert into json for consistency
 const teamApplications: ApplicationCardInfo[] = [
   {
     subteam: "Electrical",
@@ -27,7 +26,7 @@ const teamApplications: ApplicationCardInfo[] = [
         "Non-curriculum projects are highly regarded. Let us know what you’ve done!",
       ],
     },
-  },  {
+  }, {
     subteam: "Electrical",
     role: "Hardware Team Member ",
     img: "/images/join_page/join_electrical.jpg",
@@ -84,7 +83,7 @@ const teamApplications: ApplicationCardInfo[] = [
         "Passion for competitive high-speed racing.",
       ],
     },
-  },  {
+  }, {
     subteam: "Materials",
     role: "Team Member",
     img: "/images/join_page/join_materials.jpg",
@@ -207,6 +206,8 @@ const teamApplications: ApplicationCardInfo[] = [
   }
 ];
 
+const IS_RECRUITING = false;
+
 export default function Join() {
   return (
     <>
@@ -237,33 +238,38 @@ export default function Join() {
               margin: "0 auto",
             }}
           >
-            <p>Applications are open!</p>
-            <br />
-
-            <p>
+            {IS_RECRUITING ? (<><p>Applications are open!</p><br /><p>
               Apply for one of MHP&apos;s subteams below. <br />
               If you have any further questions or queries, feel free to direct
               them to monashhpt@gmail.com
-            </p>
+            </p></>) : (<><p>Recruitment is closed</p><br /><p>
+              If you have any further questions or queries, feel free to direct
+              them to monashhpt@gmail.com
+            </p></>)}
+
+
+
+
           </div>
+
+
         </div>
         <div
-          className="text-center text-xl lg:text-3xl"
-          style={{
-            paddingTop: "40px",
-            paddingBottom: "20px",
-          }}
-        >
-          {/* Expression of Interest button links to Google Form
-          <a href="https://forms.gle/U3Nn54SyTsi1WJYj7" target="_blank">
-            <button className=" font-Sansation font-semibold px-4 py-2 lg:px-16 lg:py-2 rounded-full border-2 bg-green text-black border-black hover:bg-black hover:text-white hover:border-white">
-              EOI Form
-            </button>
-          </a> */}
+          className={`${IS_RECRUITING ? "-pt-10" : "pt-10"} pb-20`}>
+
+          {IS_RECRUITING ? 
+          <ApplicationCarousel applicationInfo={teamApplications} />
+            : 
+            <a href="https://forms.gle/U3Nn54SyTsi1WJYj7" target="_blank">
+              <button className=" font-Sansation font-semibold px-4 py-2 lg:px-16 lg:py-2 rounded-full border-2 bg-green text-black border-black hover:bg-black hover:text-white hover:border-white">
+                EOI Form
+              </button>
+            </a>
+            }
+
         </div>
       </PageSection>
 
-      <ApplicationCarousel applicationInfo={teamApplications} />
     </>
   );
 }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -206,7 +206,7 @@ const teamApplications: ApplicationCardInfo[] = [
   }
 ];
 
-const IS_RECRUITING = false;
+const IS_RECRUITING = true;
 
 export default function Join() {
   return (
@@ -242,7 +242,7 @@ export default function Join() {
               Apply for one of MHP&apos;s subteams below. <br />
               If you have any further questions or queries, feel free to direct
               them to monashhpt@gmail.com
-            </p></>) : (<><p>Recruitment is closed</p><br /><p>
+            </p></>) : (<><p>Recruitment is closed.</p><br /><p>
               If you have any further questions or queries, feel free to direct
               them to monashhpt@gmail.com
             </p></>)}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -206,7 +206,7 @@ const teamApplications: ApplicationCardInfo[] = [
   }
 ];
 
-const IS_RECRUITING = true;
+const IS_RECRUITING = false;
 
 export default function Join() {
   return (

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -257,8 +257,14 @@ export default function Join() {
         <div
           className={`${IS_RECRUITING ? "-pt-10" : "pt-10"} pb-20`}>
 
-          {IS_RECRUITING &&
+          {IS_RECRUITING ? 
           <ApplicationCarousel applicationInfo={teamApplications} />
+            : 
+            <a href="https://forms.gle/U3Nn54SyTsi1WJYj7" target="_blank">
+              <button className=" font-Sansation font-semibold px-4 py-2 lg:px-16 lg:py-2 rounded-full border-2 bg-green text-black border-black hover:bg-black hover:text-white hover:border-white">
+                EOI Form
+              </button>
+            </a>
             }
 
         </div>

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -257,14 +257,8 @@ export default function Join() {
         <div
           className={`${IS_RECRUITING ? "-pt-10" : "pt-10"} pb-20`}>
 
-          {IS_RECRUITING ? 
+          {IS_RECRUITING &&
           <ApplicationCarousel applicationInfo={teamApplications} />
-            : 
-            <a href="https://forms.gle/U3Nn54SyTsi1WJYj7" target="_blank">
-              <button className=" font-Sansation font-semibold px-4 py-2 lg:px-16 lg:py-2 rounded-full border-2 bg-green text-black border-black hover:bg-black hover:text-white hover:border-white">
-                EOI Form
-              </button>
-            </a>
             }
 
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import "./globals.css";
 import Navbar from "./components/Navbar/navBar";
 import Footer from "./components/footer";
 import { GoogleAnalytics } from '@next/third-parties/google';
-import Banner from "./components/Banner";
 
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Description

This pull request removes the applications from the Join us page, and enables toggling this via a boolean on the join us page

## Screenshots

### When recruiting is closed
<img width="1920" height="1773" alt="image" src="https://github.com/user-attachments/assets/14505b67-739e-4a4f-9ffd-358dea8622ed" />

### When recruiting is open
<img width="1920" height="2638" alt="image" src="https://github.com/user-attachments/assets/b3fe726b-529f-46f5-90c3-8d36899df5dc" />


## Steps to Test
do the following usual steps to run the website locally:

```
npm install
npm run dev
```


Then in the join us page (under the directory \app\join\page.tsx), change the variable IS_RECRUITING to true and false
and view change in your browser


